### PR TITLE
blur setup can now work in view did load

### DIFF
--- a/UIView+Blur.swift
+++ b/UIView+Blur.swift
@@ -47,6 +47,14 @@ extension UIView {
          * Blur style. After it is changed all subviews on
          * blurContentView & vibrancyContentView will be deleted.
          */
+        ///Call this method when trying to preset a blur value in viewdidload
+        public func SecondaryInit(lvl:CGFloat){
+            DispatchQueue.main.asyncAfter(deadline: .now(), execute: {
+                self.intensity = 0
+                self.intensity = lvl
+            })
+        }
+        
         var style: UIBlurEffectStyle = .light {
             didSet {
                 guard oldValue != style,


### PR DESCRIPTION
I added support by calling another function to allow for the blur view to take effect durring a call to viewdidload() this is useful if you want to use this view for a background. Before this change setting up a blur would not do anything if called in viewdidload. This function fixes this by calling the intensity change after drawing of UI/UX stuff is enabled.